### PR TITLE
🔧 FIX: Remove unnecessary type attribute from script tag in index.astro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -119,7 +119,7 @@ const img =
     <!-- 👇 New Services Section -->
     <Services />
   </div>
-  <script is:inline type="text/partytown">
+  <script is:inline>
     async function downloadWithProgress() {
       const btn = document.getElementById("downloadBtn");
       const progress = document.getElementById("progressBar");


### PR DESCRIPTION
This pull request makes a small change to the `src/pages/index.astro` file, simplifying the `<script>` tag by removing the `type="text/partytown"` attribute.