### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/Sumangal44/devsumangal/security/code-scanning/1](https://github.com/Sumangal44/devsumangal/security/code-scanning/1)

To fix this, add an explicit `permissions` block in `.github/workflows/playwright.yml`. The best minimal, non-breaking fix is at the **workflow root** (top-level), so all jobs inherit it unless overridden. For this workflow, `contents: read` is the recommended baseline and is sufficient for `actions/checkout` and running tests/artifact upload in typical usage.

**Change to make:**
- In `.github/workflows/playwright.yml`, insert:
  ```yaml
  permissions:
    contents: read
  ```
  directly under the `on:` triggers section (before `jobs:`), preserving YAML indentation.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
